### PR TITLE
Add bcmath PHP extension requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     ]
   },
   "require": {
-    "php": ">=5.4.0"
+    "php": ">=5.4.0",
+    "ext-bcmath": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0"

--- a/composer.lock
+++ b/composer.lock
@@ -970,7 +970,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.4.0"
+        "php": ">=5.4.0",
+        "ext-bcmath": "*"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
This is when PHP is not compiled with bcmath (see [http://php.net/manual/en/bc.installation.php](http://php.net/manual/en/bc.installation.php)).