### PR TITLE
add getter for numberofbytes

### DIFF
--- a/src/ByteUnits/System.php
+++ b/src/ByteUnits/System.php
@@ -110,4 +110,9 @@ abstract class System
         }
         return $numberOfBytes;
     }
+
+    public function getNumberOfBytes()
+    {
+        return $this->numberOfBytes;
+    }
 }


### PR DESCRIPTION
Just a simple getter method to access the numberofbytes without the need to hack the format function. No int-conversion, just access to the string representation of the number.