### PR TITLE
Add typehinting for IDE autocompletion

### DIFF
--- a/src/ByteUnits/Binary.php
+++ b/src/ByteUnits/Binary.php
@@ -9,46 +9,82 @@ class Binary extends System
     private static $scale;
     private static $parser;
 
+    /**
+     * @param int $numberOf
+     * @return Binary
+     */
     public static function kilobytes($numberOf)
     {
         return new self(self::scale()->scaleFromUnit($numberOf, 'KiB'));
     }
 
+    /**
+     * @param int $numberOf
+     * @return Binary
+     */
     public static function megabytes($numberOf)
     {
         return new self(self::scale()->scaleFromUnit($numberOf, 'MiB'));
     }
 
+    /**
+     * @param int $numberOf
+     * @return Binary
+     */
     public static function gigabytes($numberOf)
     {
         return new self(self::scale()->scaleFromUnit($numberOf, 'GiB'));
     }
 
+    /**
+     * @param int $numberOf
+     * @return Binary
+     */
     public static function terabytes($numberOf)
     {
         return new self(self::scale()->scaleFromUnit($numberOf, 'TiB'));
     }
 
+    /**
+     * @param int $numberOf
+     * @return Binary
+     */
     public static function petabytes($numberOf)
     {
         return new self(self::scale()->scaleFromUnit($numberOf, 'PiB'));
     }
 
+    /**
+     * @param int $numberOf
+     * @return Binary
+     */
     public static function exabytes($numberOf)
     {
         return new self(self::scale()->scaleFromUnit($numberOf, 'EiB'));
     }
 
+    /**
+     * @param int $numberOf
+     * @return Binary
+     */
     public function __construct($numberOfBytes, $formatWithPrecision = self::DEFAULT_FORMAT_PRECISION)
     {
         parent::__construct($numberOfBytes, new Formatter(self::scale(), $formatWithPrecision));
     }
 
+
+    /**
+     * @return PowerScale
+     */
     public static function scale()
     {
         return self::$scale = self::$scale ?: new PowerScale(self::$base, self::$suffixes, self::COMPUTE_WITH_PRECISION);
     }
 
+
+    /**
+     * @return Parser
+     */
     public static function parser()
     {
         return self::$parser = self::$parser ?: new Parser(self::scale(), __CLASS__);

--- a/src/ByteUnits/Metric.php
+++ b/src/ByteUnits/Metric.php
@@ -14,41 +14,71 @@ class Metric extends System
         parent::__construct($numberOfBytes, new Formatter(self::scale(), $formatWithPrecision));
     }
 
+    /**
+     * @param int $numberOf
+     * @return Metric
+     */
     public static function kilobytes($numberOf)
     {
         return new self(self::scale()->scaleFromUnit($numberOf, 'kB'));
     }
 
+    /**
+     * @param int $numberOf
+     * @return Metric
+     */
     public static function megabytes($numberOf)
     {
         return new self(self::scale()->scaleFromUnit($numberOf, 'MB'));
     }
 
+    /**
+     * @param int $numberOf
+     * @return Metric
+     */
     public static function gigabytes($numberOf)
     {
         return new self(self::scale()->scaleFromUnit($numberOf, 'GB'));
     }
 
+    /**
+     * @param int $numberOf
+     * @return Metric
+     */
     public static function terabytes($numberOf)
     {
         return new self(self::scale()->scaleFromUnit($numberOf, 'TB'));
     }
 
+    /**
+     * @param int $numberOf
+     * @return Metric
+     */
     public static function petabytes($numberOf)
     {
         return new self(self::scale()->scaleFromUnit($numberOf, 'PB'));
     }
 
+    /**
+     * @param int $numberOf
+     * @return Metric
+     */
     public static function exabytes($numberOf)
     {
         return new self(self::scale()->scaleFromUnit($numberOf, 'EB'));
     }
 
+    /**
+     * @return PowerScale
+     */
     public static function scale()
     {
         return self::$scale = self::$scale ?: new PowerScale(self::$base, self::$suffixes, self::COMPUTE_WITH_PRECISION);
     }
 
+    /**
+     * @return Parser
+     */
     public static function parser()
     {
         return self::$parser = self::$parser ?: new Parser(self::scale(), __CLASS__);

--- a/src/ByteUnits/Parser.php
+++ b/src/ByteUnits/Parser.php
@@ -15,6 +15,11 @@ class Parser
         $this->system = new ReflectionClass($system);
     }
 
+    /**
+     * @param string $quantityWithUnit
+     * @return System
+     * @throws ParseException
+     */
     public function parse($quantityWithUnit)
     {
         if (preg_match('/(?P<quantity>[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)\W*(?P<unit>.*)/', $quantityWithUnit, $matches)) {

--- a/src/ByteUnits/System.php
+++ b/src/ByteUnits/System.php
@@ -10,11 +10,20 @@ abstract class System
     protected $formatter;
     protected $numberOfBytes;
 
+    /**
+     * @param int|string $numberOf
+     * @param int $formatWithPrecision
+     * @return System
+     */
     public static function bytes($numberOf, $formatWithPrecision = self::DEFAULT_FORMAT_PRECISION)
     {
         return new static($numberOf, $formatWithPrecision);
     }
 
+    /**
+     * @param string $bytesAsString
+     * @return System
+     */
     public static function parse($bytesAsString)
     {
         return static::parser()->parse($bytesAsString);
@@ -26,6 +35,10 @@ abstract class System
         $this->numberOfBytes = $this->ensureIsNotNegative($this->normalize($numberOfBytes));
     }
 
+    /**
+     * @param System $another
+     * @return System
+     */
     public function add($another)
     {
         return new static(
@@ -34,6 +47,10 @@ abstract class System
         );
     }
 
+    /**
+     * @param System $another
+     * @return System
+     */
     public function remove($another)
     {
         return new static(
@@ -42,31 +59,56 @@ abstract class System
         );
     }
 
+    /**
+     * @param System $another
+     * @return bool
+     */
     public function isEqualTo($another)
     {
         return self::compare($this, box($another)) === 0;
     }
 
+    /**
+     * @param System $another
+     * @return bool
+     */
     public function isGreaterThanOrEqualTo($another)
     {
         return self::compare($this, box($another)) >= 0;
     }
 
+    /**
+     * @param System $another
+     * @return bool
+     */
     public function isGreaterThan($another)
     {
         return self::compare($this, box($another)) > 0;
     }
 
+    /**
+     * @param System $another
+     * @return bool
+     */
     public function isLessThanOrEqualTo($another)
     {
         return self::compare($this, box($another)) <= 0;
     }
 
+    /**
+     * @param System $another
+     * @return bool
+     */
     public function isLessThan($another)
     {
         return self::compare($this, box($another)) < 0;
     }
 
+    /**
+     * @param System $left
+     * @param System $right
+     * @return int
+     */
     public static function compare($left, $right)
     {
         return bccomp(
@@ -76,21 +118,36 @@ abstract class System
         );
     }
 
+    /**
+     * @param string $howToFormat
+     * @param string $separator
+     * @return string
+     */
     public function format($howToFormat = null, $separator = '')
     {
         return $this->formatter->format($this->numberOfBytes, $howToFormat, $separator);
     }
 
+    /**
+     * @return System
+     */
     public function asBinary()
     {
         return Binary::bytes($this->numberOfBytes);
     }
 
+    /**
+     * @return System
+     */
     public function asMetric()
     {
         return Metric::bytes($this->numberOfBytes);
     }
 
+    /**
+     * @param string $numberOfBytes
+     * @return int
+     */
     private function normalize($numberOfBytes)
     {
         $numberOfBytes = (string) $numberOfBytes;
@@ -103,6 +160,11 @@ abstract class System
         return $numberOfBytes;
     }
 
+    /**
+     * @param int|string $numberOfBytes
+     * @return int|string
+     * @throws NegativeBytesException
+     */
     private function ensureIsNotNegative($numberOfBytes)
     {
         if (bccomp($numberOfBytes, 0) < 0) {
@@ -111,6 +173,9 @@ abstract class System
         return $numberOfBytes;
     }
 
+    /**
+     * @return int|string
+     */
     public function numberOfBytes()
     {
         return $this->numberOfBytes;

--- a/src/ByteUnits/functions.php
+++ b/src/ByteUnits/functions.php
@@ -23,6 +23,11 @@ function bytes($numberOf)
     return new Metric($numberOf);
 }
 
+/**
+ * @param $bytesAsString
+ * @return System
+ * @throws Exception
+ */
 function parse($bytesAsString)
 {
     $lastParseException = null;


### PR DESCRIPTION
Adding a few simple phpdoc comment blocks really simplifies use of the library in the modern IDEs, especially as the library uses fluent interfaces.
This PR should introduce no breaking changes - it contains only comments.