### PR TITLE
fix petabyte-precision

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 
 php:
   - 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
   - 7.1
   - 7.2
   - 7.4
-  - 8.0
 
 before_script:
   - composer install --prefer-source

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.4
+  - 8.0
 
 before_script:
   - composer install --prefer-source

--- a/src/ByteUnits/PowerScale.php
+++ b/src/ByteUnits/PowerScale.php
@@ -30,7 +30,7 @@ class PowerScale
         return $quantity * bcpow(
             $this->base,
             $this->scale[$unit],
-            $this->precision
+            0
         );
     }
 


### PR DESCRIPTION
I cloned your repo and I found that unittest was not running properly on my local environment with php 7.4

After some research I found that the function `bcpow` has changed in behaviour in php versione 7.3 (see changelog [here](https://www.php.net/manual/en/function.bcpow.php))

> bcpow() now returns numbers with the requested scale. Formerly, the returned numbers may have omitted trailing decimal zeroes.

PHP >= 7.3
```
var_dump(bcpow(1024,5,10)); 
//string(27) "1125899906842624.0000000000"

var_dump(1 * bcpow(1024,5,10)); 
//float(1.1258999068426E+15)
````

PHP <7.3
```
var_dump(bcpow(1024,5,10));
//string(16) "1125899906842624"

var_dump(1 * bcpow(1024,5,10));
//int(1125899906842624)
```

I've tested the fix with php 7.4 and php 8.0